### PR TITLE
Update microsoft-edge-policies.md

### DIFF
--- a/edgeenterprise/microsoft-edge-policies.md
+++ b/edgeenterprise/microsoft-edge-policies.md
@@ -9718,7 +9718,7 @@ If the [DefaultSearchProviderSearchURL](#defaultsearchprovidersearchurl) policy 
   - Value Type: REG_SZ
   ##### Example value:
 ```
-SOFTWARE\Policies\Microsoft\Edge\ManagedSearchEngines = [
+[
   {
     "is_default": true, 
     "keyword": "example1.com", 


### PR DESCRIPTION
Within line 9721, I propose to remove "SOFTWARE\Policies\Microsoft\Edge\ManagedSearchEngines =" and leave the following code. The reason I'm asking this is related with the direct opportunity to copy the example into the policy which will not work if includes  SOFTWARE\Policies\Microsoft\Edge\ManagedSearchEngines =

  ##### Example value:
```
[
  {
    "is_default": true, 
    "keyword": "example1.com", 
    "name": "Example1", 
    "search_url": "https://www.example1.com/search?q={searchTerms}", 
    "suggest_url": "https://www.example1.com/qbox?query={searchTerms}"
  }, 
  {
    "image_search_post_params": "content={imageThumbnail},url={imageURL},sbisrc={SearchSource}", 
    "image_search_url": "https://www.example2.com/images/detail/search?iss=sbiupload", 
    "keyword": "example2.com", 
    "name": "Example2", 
    "search_url": "https://www.example2.com/search?q={searchTerms}", 
    "suggest_url": "https://www.example2.com/qbox?query={searchTerms}"
  }, 
  {
    "encoding": "UTF-8", 
    "image_search_url": "https://www.example3.com/images/detail/search?iss=sbiupload", 
    "keyword": "example3.com", 
    "name": "Example3", 
    "search_url": "https://www.example3.com/search?q={searchTerms}", 
    "suggest_url": "https://www.example3.com/qbox?query={searchTerms}"
  }, 
  {
    "keyword": "example4.com", 
    "name": "Example4", 
    "search_url": "https://www.example4.com/search?q={searchTerms}"
  }
]
```